### PR TITLE
Update Swift target version.

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.1.1"
-github "ReactiveX/RxSwift" "4.1.2"
+github "Quick/Nimble" "v8.0.4"
+github "ReactiveX/RxSwift" "5.0.1"

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -312,7 +313,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fellipecaetano.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -330,7 +331,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fellipecaetano.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -5,7 +5,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     private let store = CounterStore()
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = CounterViewController(store: store)
         window?.makeKeyAndVisible()

--- a/Redux.swift.podspec
+++ b/Redux.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Redux.swift'
   s.module_name = 'Redux'
-  s.version = '5.0.1'
+  s.version = '5.1.0'
   s.summary = 'An implementation of a predictable state container in Swift.'
   s.description = <<-DESC
 Redux.swift is an implementation of a predictable state container, written in Swift. It aims to enforce separation of concerns and a unidirectional data flow by keeping your entire app state in a single data structure that cannot be mutated directly, instead relying on an action dispatch mechanism to describe changes.

--- a/Redux.swift.podspec
+++ b/Redux.swift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Redux.swift'
   s.module_name = 'Redux'
-  s.version = '5.0.0'
+  s.version = '5.0.1'
   s.summary = 'An implementation of a predictable state container in Swift.'
   s.description = <<-DESC
 Redux.swift is an implementation of a predictable state container, written in Swift. It aims to enforce separation of concerns and a unidirectional data flow by keeping your entire app state in a single data structure that cannot be mutated directly, instead relying on an action dispatch mechanism to describe changes.

--- a/Source/Rx/Redux+Rx.swift
+++ b/Source/Rx/Redux+Rx.swift
@@ -21,5 +21,5 @@ public extension Dispatcher {
 }
 
 extension Store: ObservableType {
-    public typealias E = State
+    public typealias Element = State
 }


### PR DESCRIPTION
Some minor changes to help Example project to compile using Carthage.
- Update Swift target version to 4.2;
- App delegate's method didFinishLaunchingWithOptions;
- Update ObservableType's type alias.
